### PR TITLE
Window positioning and attribute updating.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INDEXED_VERSION = 0.0.8 # indexed Idris package
 LD_OVERRIDE ?= 
 
 TARGET = libncurses-idris
-TARGET_VERSION ?= 0.0.5
+TARGET_VERSION ?= 0.0.6
 
 PACKAGE_INSTALLDIR = `${IDRIS} --libdir`
 SHAREDLIB_INSTALLDIR = ${PACKAGE_INSTALLDIR}/ncurses-idris-${TARGET_VERSION}/lib

--- a/examples/control_curses/Main.idr
+++ b/examples/control_curses/Main.idr
@@ -33,20 +33,20 @@ run = Indexed.Do.do
   addColor "alert" White Red
   clear
   -- direct invocation
-  setAttr (Color "inverse")
+  setAttr (Color (Named "inverse"))
   putStr "Ctrl+C to exit\n\n"
   setAttr Underline
   putStr "Hello World\n\n"
-  setAttrs [(Color "alert"), Bold]
+  setAttrs [(Color (Named "alert")), Bold]
   putStr "THIS IS NOT A PROBLEM"
   setAttr Normal
   putStrLn "\n\nEnd of initial transmission."
   addWindow "win1" (MkPosition 35 55) (MkSize 20 30) Nothing
   setWindow "win1"
   clear
-  setAttr (Color "inverse")
+  setAttr (Color (Named "inverse"))
   putStrLn "hello from a window"
-  setAttr DefaultColors
+  setAttr (Color DefaultColors)
   refresh
   setWindow "main"
   -- pretty print

--- a/examples/control_pumpkin/Main.idr
+++ b/examples/control_pumpkin/Main.idr
@@ -91,7 +91,7 @@ instructions = indent ((width `minus` (length unpadded)) `div` 2) unpadded
     unpadded = "Ctrl+C to quit. 't' to toggle eyes!"
 
 drawLines : IsActive s => (color : String) -> HasColor color s => List Line -> NCurses () s s
-drawLines color xs = setAttr (Color color) >> traverse_ drawLine xs
+drawLines color xs = setAttr (Color (Named color)) >> traverse_ drawLine xs
   where
     drawLine : (Nat, Nat, Nat) -> NCurses () s s
     drawLine (row, col, len) = do

--- a/examples/control_stateful/Main.idr
+++ b/examples/control_stateful/Main.idr
@@ -76,11 +76,11 @@ run = Indexed.Do.do
   addWindow "options" (MkPosition 1 0) (MkSize 10 10) Nothing
   addColor "heading" White Red
   clear
-  setAttr (Color "heading")
+  setAttr (Color (Named "heading"))
   putStr "Ctrl+C to exit, arrow keys to select a row."
   refresh
   setWindow "options"
-  setAttr DefaultColors
+  setAttr (Color DefaultColors)
   evalStateT (init items) loop
   deinit
 

--- a/ncurses-idris.ipkg
+++ b/ncurses-idris.ipkg
@@ -1,6 +1,6 @@
 package ncurses-idris
 
-version = 0.0.5
+version = 0.0.6
 
 sourcedir = "src"
 

--- a/src/Control/NCurses.idr
+++ b/src/Control/NCurses.idr
@@ -187,15 +187,21 @@ identifiesCurrentWindow {ws} @{p} with (hasWindowWithin @{p})
 public export
 %hint
 hasWindowStill : HasWindow n s => HasWindow w s => HasWindow n (setWindow s w)
-hasWindowStill {n} {w} {s = (Active _ (MkWindow n _ _ :: ws) _ _)} @{ItHasWindow  @{Here}} @{ItHasWindow} = ItHasWindow
-hasWindowStill {n} {w} {s = Active _ [] _ _} @{ItHasWindow  @{Here}} impossible
-hasWindowStill {n} {w} {s = (Active _ (y :: ws) _ _)} @{ItHasWindow  @{There x}} @{ItHasWindow} = ItHasWindow @{There x}
-hasWindowStill {n} {w} {s = Active _ [] _ _} @{ItHasWindow  @{There x}} impossible
+hasWindowStill {s = (Active _ (MkWindow n _ _ :: ws) _ _)} @{ItHasWindow  @{Here}} @{ItHasWindow} = ItHasWindow
+hasWindowStill {s = Active _ [] _ _} @{ItHasWindow  @{Here}} impossible
+hasWindowStill {s = (Active _ (y :: ws) _ _)} @{ItHasWindow  @{There x}} @{ItHasWindow} = ItHasWindow @{There x}
+hasWindowStill {s = Active _ [] _ _} @{ItHasWindow  @{There x}} impossible
 
 public export
 %hint
 isActiveStill : IsActive s => HasWindow w s => IsActive (setWindow s w)
 isActiveStill @{ItIsActive} @{ItHasWindow} = ItIsActive
+
+public export
+%hint
+hasColorStill : HasColor c s => HasWindow w s => HasColor c (setWindow s w)
+hasColorStill {s = (Active _ _ _ (c :: xs))} @{ItHasColor  @{Here}} @{ItHasWindow} = ItHasColor
+hasColorStill {s = (Active _ _ _ (y :: xs))} @{ItHasColor  @{(There x)}} @{ItHasWindow} = ItHasColor
 
 public export
 identifiedWindowExists : IdentifiesWindow w ws -> Exists (\k => Exists (\d => lookupWindow w ws = MkWindow w k d))

--- a/src/Control/NCurses.idr
+++ b/src/Control/NCurses.idr
@@ -186,22 +186,41 @@ identifiesCurrentWindow {ws} @{p} with (hasWindowWithin @{p})
 ||| change the fact that the state has the original window.
 public export
 %hint
-hasWindowStill : HasWindow n s => HasWindow w s => HasWindow n (setWindow s w)
-hasWindowStill {s = (Active _ (MkWindow n _ _ :: ws) _ _)} @{ItHasWindow  @{Here}} @{ItHasWindow} = ItHasWindow
-hasWindowStill {s = Active _ [] _ _} @{ItHasWindow  @{Here}} impossible
-hasWindowStill {s = (Active _ (y :: ws) _ _)} @{ItHasWindow  @{There x}} @{ItHasWindow} = ItHasWindow @{There x}
-hasWindowStill {s = Active _ [] _ _} @{ItHasWindow  @{There x}} impossible
+setWindowHasWindowStill : HasWindow n s => HasWindow w s => HasWindow n (setWindow s w)
+setWindowHasWindowStill {s = (Active _ (MkWindow n _ _ :: ws) _ _)} @{ItHasWindow  @{Here}} @{ItHasWindow} = ItHasWindow
+setWindowHasWindowStill {s = Active _ [] _ _} @{ItHasWindow  @{Here}} impossible
+setWindowHasWindowStill {s = (Active _ (y :: ws) _ _)} @{ItHasWindow  @{There x}} @{ItHasWindow} = ItHasWindow @{There x}
+setWindowHasWindowStill {s = Active _ [] _ _} @{ItHasWindow  @{There x}} impossible
 
 public export
 %hint
-isActiveStill : IsActive s => HasWindow w s => IsActive (setWindow s w)
-isActiveStill @{ItIsActive} @{ItHasWindow} = ItIsActive
+setWindowIsActiveStill : IsActive s => HasWindow w s => IsActive (setWindow s w)
+setWindowIsActiveStill @{ItIsActive} @{ItHasWindow} = ItIsActive
 
 public export
 %hint
-hasColorStill : HasColor c s => HasWindow w s => HasColor c (setWindow s w)
-hasColorStill {s = (Active _ _ _ (c :: xs))} @{ItHasColor  @{Here}} @{ItHasWindow} = ItHasColor
-hasColorStill {s = (Active _ _ _ (y :: xs))} @{ItHasColor  @{(There x)}} @{ItHasWindow} = ItHasColor
+setWindowHasColorStill : HasColor c s => HasWindow w s => HasColor c (setWindow s w)
+setWindowHasColorStill {s = (Active _ _ _ (c :: xs))} @{ItHasColor  @{Here}} @{ItHasWindow} = ItHasColor
+setWindowHasColorStill {s = (Active _ _ _ (y :: xs))} @{ItHasColor  @{(There x)}} @{ItHasWindow} = ItHasColor
+
+||| If a given state has a window, setting a new current window on that state does not
+||| change the fact that the state has the original window.
+public export
+%hint
+addWindowHasWindowStill : IsActive s => HasWindow n s => HasWindow n (addWindow s w)
+addWindowHasWindowStill {s = (Active _ (_ :: ws) _ _)} @{ItIsActive} @{ItHasWindow @{Here}} = ItHasWindow
+addWindowHasWindowStill {s = (Active _ (_ :: ws) _ _)} @{ItIsActive} @{ItHasWindow @{(There x)}} = ItHasWindow
+
+public export
+%hint
+addWindowIsActiveStill : IsActive s => IsActive (addWindow s w)
+addWindowIsActiveStill @{ItIsActive} = ItIsActive
+
+public export
+%hint
+addWindowHasColorStill : IsActive s => HasColor c s => HasColor c (addWindow s w)
+addWindowHasColorStill {s = (Active _ _ _ (c :: xs))} @{ItIsActive} @{ItHasColor @{Here}} = ItHasColor
+addWindowHasColorStill {s = (Active _ _ _ (y :: xs))} @{ItIsActive} @{ItHasColor @{(There x)}} = ItHasColor
 
 public export
 identifiedWindowExists : IdentifiesWindow w ws -> Exists (\k => Exists (\d => lookupWindow w ws = MkWindow w k d))
@@ -513,7 +532,7 @@ testRoutine = Indexed.Do.do
       insideWindowTwice : IsActive s => InWindow "win2" s => (w : _) -> HasWindow w s => NCurses () s s
       insideWindowTwice w = do
         erase
-        inWindow w (insideWindow w @{isActiveStill} @{inWindowNow})
+        inWindow w (insideWindow w @{setWindowIsActiveStill} @{inWindowNow})
         refresh
 
 --

--- a/src/Control/NCurses/Pretty.idr
+++ b/src/Control/NCurses/Pretty.idr
@@ -13,11 +13,11 @@ import Control.Indexed
 ||| See also @defaultColor@.
 export
 color : (name : String) -> HasColor name s => Doc (Attribute s) -> Doc (Attribute s)
-color name = annotate (Color name)
+color name = annotate (Color (Named name))
 
 export
 defaultColor : Doc (Attribute s) -> Doc (Attribute s)
-defaultColor = annotate DefaultColors
+defaultColor = annotate (Color DefaultColors)
 
 export
 underline : Doc (Attribute s) -> Doc (Attribute s)

--- a/src/Control/NCurses/State.idr
+++ b/src/Control/NCurses/State.idr
@@ -210,6 +210,11 @@ namespace Attribute
     ItHasColor : Elem name cs => HasColor name (Active _ _ w cs)
 
   public export
+  data ColorAttr : CursesState -> Type where
+    DefaultColors : ColorAttr s
+    Named : (name : String) -> HasColor name s => ColorAttr s
+
+  public export
   data Attribute : CursesState -> Type where
     Normal        : Attribute s
     Underline     : Attribute s
@@ -220,15 +225,14 @@ namespace Attribute
     Bold          : Attribute s
     Protected     : Attribute s
     Invisible     : Attribute s
-    DefaultColors : Attribute s
-    Color         : (name : String) -> HasColor name s => Attribute s
+    Color         : ColorAttr s -> Attribute s
 
   public export
   data AttrCmd : CursesState -> Type where
     SetAttr     : Attribute s -> AttrCmd s
     EnableAttr  : Attribute s -> AttrCmd s
     DisableAttr : Attribute s -> AttrCmd s
-    UpdateAttr  : Attribute s -> (color : String) -> HasColor color s => (length : Maybe Nat) -> AttrCmd s
+    UpdateAttr  : Attribute s -> ColorAttr s -> (length : Maybe Nat) -> AttrCmd s
 
 ||| A Window border.
 public export

--- a/src/Control/NCurses/State.idr
+++ b/src/Control/NCurses/State.idr
@@ -228,6 +228,7 @@ namespace Attribute
     SetAttr     : Attribute s -> AttrCmd s
     EnableAttr  : Attribute s -> AttrCmd s
     DisableAttr : Attribute s -> AttrCmd s
+    UpdateAttr  : Attribute s -> (color : String) -> HasColor color s => (length : Maybe Nat) -> AttrCmd s
 
 ||| A Window border.
 public export

--- a/src/Control/NCurses/State.idr
+++ b/src/Control/NCurses/State.idr
@@ -207,7 +207,7 @@ namespace Attribute
   ||| NCurses session.
   public export
   data HasColor : (0 name : String) -> CursesState -> Type where
-    ItHasColor : Elem name cs => HasColor name (Active _ ws w cs)
+    ItHasColor : Elem name cs => HasColor name (Active _ _ w cs)
 
   public export
   data Attribute : CursesState -> Type where


### PR DESCRIPTION
**Breaking Changes**
- rename `nChangeAttr` to `nChangeAttrAt` and same for `nChangeAttr'` -> `nChangeAttrAt'`.
- move `Attribute`'s `DefaultColors` into the new `ColorAttr` type along with the `NamedColor` constructor that used to be `Attribute`'s `Color` constructor.

**Additions**
- `deleteWindow` and `moveWindow` in `NCurses.Core`.
- `nChangeAttr` reintroduced in `NCurses.Core` (see note about renaming above) but as a function that does not move the cursor prior to changing the attribute for some number length of characters.
-  `updateAttr` and `setPos` in `Control.NCurses`.