### PR TITLE
Fix key retrieval via FFI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INDEXED_VERSION = 0.0.8 # indexed Idris package
 LD_OVERRIDE ?= 
 
 TARGET = libncurses-idris
-TARGET_VERSION ?= 0.0.6
+TARGET_VERSION ?= 0.0.7
 
 PACKAGE_INSTALLDIR = `${IDRIS} --libdir`
 SHAREDLIB_INSTALLDIR = ${PACKAGE_INSTALLDIR}/ncurses-idris-${TARGET_VERSION}/lib

--- a/examples/key_logger/Main.idr
+++ b/examples/key_logger/Main.idr
@@ -1,0 +1,49 @@
+module Main
+
+import System
+import System.Signal
+import NCurses
+import Text.PrettyPrint.Prettyprinter.Render.NCurses
+import Text.PrettyPrint.Prettyprinter.Render.Terminal
+import Text.PrettyPrint.Prettyprinter.Doc
+
+loop : HasIO io => io ()
+loop = do
+  key <- safeGetCh
+  case key of
+       Nothing => nPutStrLn " ERROR"
+       Just c  => nPutStrLn " char: \{show c}, int: \{show (the Int (cast c))}"
+  case !handleNextCollectedSignal of
+       (Just SigINT) => pure ()
+       _ => loop
+
+main : IO ()
+main = do
+  ignore $ collectSignal SigINT
+  initNCurses
+  startColor
+  keypad True
+  clear
+  nPutStrLn "Ctrl+C to quit."
+  nPutStrLn "F0: \{show !(fnKeyChar F0)}"
+  nPutStrLn "F1: \{show !(fnKeyChar F0)}"
+  nPutStrLn "F2: \{show !(fnKeyChar F2)}"
+  nPutStrLn "F3: \{show !(fnKeyChar F3)}"
+  nPutStrLn "F4: \{show !(fnKeyChar F4)}"
+  nPutStrLn "F5: \{show !(fnKeyChar F5)}"
+  nPutStrLn "F6: \{show !(fnKeyChar F6)}"
+  nPutStrLn "F7: \{show !(fnKeyChar F7)}"
+  nPutStrLn "F8: \{show !(fnKeyChar F8)}"
+  nPutStrLn "F9: \{show !(fnKeyChar F9)}"
+  nPutStrLn "F10: \{show !(fnKeyChar F10)}"
+  nPutStrLn "F11: \{show !(fnKeyChar F11)}"
+  nPutStrLn "F12: \{show !(fnKeyChar F12)}"
+  nPutStrLn "UP: \{show !(fnKeyChar Up)}"
+  nPutStrLn "DOWN: \{show !(fnKeyChar Down)}"
+  nPutStrLn "LEFT: \{show !(fnKeyChar Left)}"
+  nPutStrLn "RIGHT: \{show !(fnKeyChar Right)}"
+  nPutStrLn "BACKSPACE: \{show !(fnKeyChar Backspace)}"
+  refresh
+  loop
+  deinitNCurses
+

--- a/examples/key_logger/Makefile
+++ b/examples/key_logger/Makefile
@@ -1,0 +1,31 @@
+
+IDRIS ?= "idris2"
+
+INSTALL_DIR=./depends/ncurses-idris-0
+
+CC_VERSION = $(shell $(CC) --version)
+
+ifeq ($(findstring clang,$(CC_VERSION)),clang)
+ DYLIB_WORKAROUND = cp "../../libncurses-idris" "${INSTALL_DIR}/lib/libncurses-idris.dylib"
+else
+ DYLIB_WORKAROUND = cp "../../libncurses-idris" "${INSTALL_DIR}/lib/libncurses-idris.so"
+ CFLAGS += -fPIC
+ LDFLAGS += -fuse-ld=gold
+endif
+
+.PHONY : all
+
+all :
+	mkdir -p depends/ncurses-idris-0/lib
+	cd ../.. && \
+	make && \
+	cd - && \
+	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	$(DYLIB_WORKAROUND)
+	$(IDRIS) --build key_logger.ipkg
+
+.PHONY : clean
+
+clean :
+	rm -rf ./build
+	rm -rf ./depends

--- a/examples/key_logger/key_logger.ipkg
+++ b/examples/key_logger/key_logger.ipkg
@@ -1,0 +1,6 @@
+package key_logger
+
+depends = contrib, ncurses-idris
+
+executable = "key_logger"
+main = Main

--- a/ncurses-idris.ipkg
+++ b/ncurses-idris.ipkg
@@ -1,6 +1,6 @@
 package ncurses-idris
 
-version = 0.0.6
+version = 0.0.7
 
 sourcedir = "src"
 

--- a/src/Control/NCurses.idr
+++ b/src/Control/NCurses.idr
@@ -971,10 +971,14 @@ runNCurses GetCh rs@(RActive as@(MkCursesActive windows {w} ((MkRuntimeWindow (M
                  else do ch <- safeGetCh' (getCoreWindow as)
                          pure (ch, rewrite currentWindowPropsPrf e' wPrf in rs)
          else if keypad
-                then do ch <- getCh' (getCoreWindow as)
+                then do Just ch <- safeGetCh' (getCoreWindow as)
+                          | Nothing => pure (Left ' ', rewrite currentWindowPropsPrf e' wPrf in rs)
+                          --                  ^ TODO: this is no good, we should report this error rather than fudge it.
                         let keyOrCh = maybeToEither ch (lookup ch keyMap)
                         pure (keyOrCh, rewrite currentWindowPropsPrf e' wPrf in rs)
-                else do ch <- getCh' (getCoreWindow as)
+                else do Just ch <- safeGetCh' (getCoreWindow as)
+                          | Nothing => pure (' ', rewrite currentWindowPropsPrf e' wPrf in rs)
+                          --                  ^ TODO: this is no good, we should report this error rather than fudge it.
                         pure (ch, rewrite currentWindowPropsPrf e' wPrf in rs)
 runNCurses (InWindow _ @{_} @{ItHasWindow @{elem}} nc) rs@(RActive as) = do
   r <- runNCurses nc (RActive $ setRuntimeWindow elem as)

--- a/src/NCurses/Core/SpecialKey.idr
+++ b/src/NCurses/Core/SpecialKey.idr
@@ -11,58 +11,58 @@ import Data.Either
 prim__keypad : AnyPtr -> Int -> PrimIO ()
 
 %foreign libhelper "keyF0"
-prim__keyF0 : PrimIO Char
+prim__keyF0 : PrimIO Int
 
 %foreign libhelper "keyF1"
-prim__keyF1 : PrimIO Char
+prim__keyF1 : PrimIO Int
 
 %foreign libhelper "keyF2"
-prim__keyF2 : PrimIO Char
+prim__keyF2 : PrimIO Int
 
 %foreign libhelper "keyF3"
-prim__keyF3 : PrimIO Char
+prim__keyF3 : PrimIO Int
 
 %foreign libhelper "keyF4"
-prim__keyF4 : PrimIO Char
+prim__keyF4 : PrimIO Int
 
 %foreign libhelper "keyF5"
-prim__keyF5 : PrimIO Char
+prim__keyF5 : PrimIO Int
 
 %foreign libhelper "keyF6"
-prim__keyF6 : PrimIO Char
+prim__keyF6 : PrimIO Int
 
 %foreign libhelper "keyF7"
-prim__keyF7 : PrimIO Char
+prim__keyF7 : PrimIO Int
 
 %foreign libhelper "keyF8"
-prim__keyF8 : PrimIO Char
+prim__keyF8 : PrimIO Int
 
 %foreign libhelper "keyF9"
-prim__keyF9 : PrimIO Char
+prim__keyF9 : PrimIO Int
 
 %foreign libhelper "keyF10"
-prim__keyF10 : PrimIO Char
+prim__keyF10 : PrimIO Int
 
 %foreign libhelper "keyF11"
-prim__keyF11 : PrimIO Char
+prim__keyF11 : PrimIO Int
 
 %foreign libhelper "keyF12"
-prim__keyF12 : PrimIO Char
+prim__keyF12 : PrimIO Int
 
 %foreign libhelper "keyUp"
-prim__keyUp : PrimIO Char
+prim__keyUp : PrimIO Int
 
 %foreign libhelper "keyDown"
-prim__keyDown : PrimIO Char
+prim__keyDown : PrimIO Int
 
 %foreign libhelper "keyLeft"
-prim__keyLeft : PrimIO Char
+prim__keyLeft : PrimIO Int
 
 %foreign libhelper "keyRight"
-prim__keyRight : PrimIO Char
+prim__keyRight : PrimIO Int
 
 %foreign libhelper "keyBackspace"
-prim__keyBackspace : PrimIO Char
+prim__keyBackspace : PrimIO Int
 
 ||| Keys that can be used when keypad is turned on.
 ||| See @keypad@ and @keypad'@.
@@ -134,24 +134,24 @@ allKeysCover Backspace = %search
 ||| See @keypad@ and @keypad'@.
 export
 fnKeyChar : HasIO io => Key -> io Char
-fnKeyChar F0        = primIO $ prim__keyF0
-fnKeyChar F1        = primIO $ prim__keyF1
-fnKeyChar F2        = primIO $ prim__keyF2
-fnKeyChar F3        = primIO $ prim__keyF3
-fnKeyChar F4        = primIO $ prim__keyF4
-fnKeyChar F5        = primIO $ prim__keyF5
-fnKeyChar F6        = primIO $ prim__keyF6
-fnKeyChar F7        = primIO $ prim__keyF7
-fnKeyChar F8        = primIO $ prim__keyF8
-fnKeyChar F9        = primIO $ prim__keyF9
-fnKeyChar F10       = primIO $ prim__keyF10
-fnKeyChar F11       = primIO $ prim__keyF11
-fnKeyChar F12       = primIO $ prim__keyF12
-fnKeyChar Up        = primIO $ prim__keyUp
-fnKeyChar Down      = primIO $ prim__keyDown
-fnKeyChar Left      = primIO $ prim__keyLeft
-fnKeyChar Right     = primIO $ prim__keyRight
-fnKeyChar Backspace = primIO $ prim__keyBackspace
+fnKeyChar F0        = cast <$> (primIO prim__keyF0)
+fnKeyChar F1        = cast <$> (primIO prim__keyF1)
+fnKeyChar F2        = cast <$> (primIO prim__keyF2)
+fnKeyChar F3        = cast <$> (primIO prim__keyF3)
+fnKeyChar F4        = cast <$> (primIO prim__keyF4)
+fnKeyChar F5        = cast <$> (primIO prim__keyF5)
+fnKeyChar F6        = cast <$> (primIO prim__keyF6)
+fnKeyChar F7        = cast <$> (primIO prim__keyF7)
+fnKeyChar F8        = cast <$> (primIO prim__keyF8)
+fnKeyChar F9        = cast <$> (primIO prim__keyF9)
+fnKeyChar F10       = cast <$> (primIO prim__keyF10)
+fnKeyChar F11       = cast <$> (primIO prim__keyF11)
+fnKeyChar F12       = cast <$> (primIO prim__keyF12)
+fnKeyChar Up        = cast <$> (primIO prim__keyUp)
+fnKeyChar Down      = cast <$> (primIO prim__keyDown)
+fnKeyChar Left      = cast <$> (primIO prim__keyLeft)
+fnKeyChar Right     = cast <$> (primIO prim__keyRight)
+fnKeyChar Backspace = cast <$> (primIO prim__keyBackspace)
 
 fnKeyPairing : HasIO io => Key -> (io Char, Key)
 fnKeyPairing k = (fnKeyChar k, k)


### PR DESCRIPTION
Receiving keys as chars via the FFI was causing the `<Return>` and `<F2>` keys to have the same value. It's fine to cast them to chars within Idris, they just need to be received as Ints across the FFI boundary.