### PR TITLE
Fix root and example project Makefiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ PACKAGE_INSTALLDIR = `${IDRIS} --libdir`
 ifeq (${NCURSES_VERSION},)
 	NCURSES_WORKAROUND = echo 'Using versionless NCurses lib.'
 else
-	NCURSES_WORKAROUND = cat Core.idr | sed 's/libncurses"/libncurses $(NCURSES_VERSION)"/' > tmp.idr && \
+	NCURSES_WORKAROUND = echo "Using NCurses lib version ${NCURSES_VERSION}." && \
+			     cat Core.idr | sed 's/libncurses,ncurses.h"/libncurses $(NCURSES_VERSION),ncurses.h"/' > tmp.idr && \
 	                     rm Core.idr && mv tmp.idr Core.idr
 endif
 

--- a/examples/control_bordered/Makefile
+++ b/examples/control_bordered/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build control_bordered.ipkg
 
 clean :

--- a/examples/control_curses/Makefile
+++ b/examples/control_curses/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build control_curses.ipkg
 
 clean :

--- a/examples/control_curses_ticker/Makefile
+++ b/examples/control_curses_ticker/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build control_curses_ticker.ipkg
 
 clean :

--- a/examples/control_in_window/Makefile
+++ b/examples/control_in_window/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build control_in_window.ipkg
 
 clean :

--- a/examples/control_pumpkin/Makefile
+++ b/examples/control_pumpkin/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build control_pumpkin.ipkg
 
 clean :

--- a/examples/control_stateful/Makefile
+++ b/examples/control_stateful/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build control_stateful.ipkg
 
 clean :

--- a/examples/doc_ann/Makefile
+++ b/examples/doc_ann/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build doc_ann.ipkg
 
 .PHONY : clean

--- a/examples/key_logger/Makefile
+++ b/examples/key_logger/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build key_logger.ipkg
 
 .PHONY : clean

--- a/examples/timed/Makefile
+++ b/examples/timed/Makefile
@@ -20,7 +20,10 @@ all :
 	cd ../.. && \
 	make && \
 	cd - && \
+	cp -R ../../depends/* ./depends/ && \
 	cp -R ../../build/ttc/* ./depends/ncurses-idris-0 && \
+	(cp ../../support/*.dylib ./depends/ncurses-idris-0/lib/ || \
+	cp ../../support/*.so ./depends/ncurses-idris-0/lib/) && \
 	$(IDRIS) --build timed.ipkg
 
 .PHONY : clean


### PR DESCRIPTION
Fixes https://github.com/mattpolzin/ncurses-idris/issues/26.

- fix root makefile to substitute correct string when setting the ncurses version.
- fix example makefiles to pull all local depends and libs.