### PR TITLE
[ fix ] Fix issues with varargs FFI on M1 mac

### DIFF
--- a/src/NCurses/Core.idr
+++ b/src/NCurses/Core.idr
@@ -63,10 +63,10 @@ prim__erase : PrimIO ()
 %foreign libncurses "werase"
 prim__eraseWindow : AnyPtr -> PrimIO ()
 
-%foreign libncurses "printw"
+%foreign libhelper "print"
 prim__print : String -> String -> PrimIO ()
 
-%foreign libncurses "wprintw"
+%foreign libhelper "printWindow"
 prim__printWindow : AnyPtr -> String -> String -> PrimIO ()
 
 %foreign libncurses "addch"
@@ -83,10 +83,10 @@ prim__addCharWindow : AnyPtr -> Char -> PrimIO ()
 |||
 ||| The second to last argument is a format string but
 ||| its best to just always pass strings ("%s").
-%foreign libncurses "mvprintw"
+%foreign libhelper "mvPrint"
 prim__mvPrint : Int -> Int -> String -> String -> PrimIO ()
 
-%foreign libncurses "mvwprintw"
+%foreign libhelper "mvPrintWindow"
 prim__mvPrintWindow : AnyPtr -> Int -> Int -> String -> String -> PrimIO ()
 
 %foreign libncurses "vline"

--- a/support/curses-helpers.c
+++ b/support/curses-helpers.c
@@ -154,3 +154,18 @@ int keyBackspace() {
   return KEY_BACKSPACE;
 }
 
+int print(const char* fmt, const char* arg) {
+  return printw(fmt, arg);
+}
+
+int printWindow(WINDOW* win, const char* fmt, const char* arg) {
+  return wprintw(win, fmt, arg);
+}
+
+int mvPrint(int x, int y, const char* fmt, char* arg) {
+  return mvprintw(x, y, fmt, arg);
+}
+
+int mvPrintWindow(WINDOW* win, int x, int y, const char* fmt, char* arg) {
+  return mvwprintw(win, x, y, fmt, arg); 
+}

--- a/support/curses-helpers.c
+++ b/support/curses-helpers.c
@@ -162,10 +162,10 @@ int printWindow(WINDOW* win, const char* fmt, const char* arg) {
   return wprintw(win, fmt, arg);
 }
 
-int mvPrint(int x, int y, const char* fmt, char* arg) {
-  return mvprintw(x, y, fmt, arg);
+int mvPrint(int y, int x, const char* fmt, char* arg) {
+  return mvprintw(y, x, fmt, arg);
 }
 
-int mvPrintWindow(WINDOW* win, int x, int y, const char* fmt, char* arg) {
-  return mvwprintw(win, x, y, fmt, arg); 
+int mvPrintWindow(WINDOW* win, int y, int x, const char* fmt, char* arg) {
+  return mvwprintw(win, y, x, fmt, arg); 
 }


### PR DESCRIPTION
On M1 macs, the calling conventions for varargs arguments are incompatible with acting like the function is not varargs.  In this PR. This causes scrambled text in the output of ncurses-idris.  In this PR, I add helper functions that match the FFI signatures being used for `printw`, `wprintw`, `mvprintw`, and `mvwprintw` to address the issue.  This fixes `tetris` and the other examples on M1 mac.

